### PR TITLE
Fix typo in return value of SnackRowMapper::mapRow

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ public class SnackRowMapper implements RowMapper<Snack> {
         s.snacknr = rs.getInt("snacknr");
         s.snacknaam = rs.getString("snacknaam");
         s.calorieen = rs.getInt("calorieen");
-        return d;
+        return s;
     }
 }
 ```


### PR DESCRIPTION
Duplicate of #1 because it was opened with a different account